### PR TITLE
Implement hostname exceptions

### DIFF
--- a/background.js
+++ b/background.js
@@ -36,7 +36,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
 
     if (allowList.find((domain) => hostname === domain)) {
       return;
-    } else if (blockList.find((domain) => hostname === domain)) {
+    } else if (blockList.find((domain) => hostname.includes(domain))) {
       chrome.tabs.remove(tabId);
     }
   });

--- a/background.js
+++ b/background.js
@@ -24,7 +24,19 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
 
   chrome.storage.local.get(["blocked", "enabled"], function (local) {
     const { blocked, enabled } = local;
-    if (Array.isArray(blocked) && enabled && blocked.find(domain => hostname.includes(domain))) {
+    if (!Array.isArray(blocked) || !enabled) {
+      return;
+    }
+
+    const allowList = blocked
+      .filter((item) => item.startsWith("!"))
+      .map((hostname) => hostname.substring(1));
+
+    const blockList = blocked.filter((item) => !item.startsWith("!"));
+
+    if (allowList.find((domain) => hostname === domain)) {
+      return;
+    } else if (blockList.find((domain) => hostname === domain)) {
       chrome.tabs.remove(tabId);
     }
   });


### PR DESCRIPTION
Solves https://github.com/penge/block-site/issues/9. 

With this approach, there might be breaking changes for current users. 
Up to now the filter `youtube.com` also blocks the automatic forwarding to `www.youtube.com`. This is no longer the case because we compare for the _exact_ hostname. 
To circumvent this we either (1) ignore `www.` in general or (2) leave it to the user and write an information to the options page.

Edit: I updated the comparison. Only the whitelist domains have **exact** comparison, the block list domains will be compared using the `includes` method. So nothing will change for current users. 