### PR TITLE
Make textarea wider, don't wrap long lines

### DIFF
--- a/options.html
+++ b/options.html
@@ -24,6 +24,7 @@
     outline: none;
     font-size: inherit;
     line-height: inherit;
+    white-space: pre;
   }
   #textarea::placeholder {
     color: silver;
@@ -59,7 +60,7 @@
   Sites starting with <code>!</code> will be exception to the rule, allowed.
 </p>
 
-<textarea id="textarea" rows="10" cols="30" spellcheck="false"></textarea>
+<textarea id="textarea" rows="10" cols="50" spellcheck="false"></textarea>
 <br>
 
 <div id="controls">


### PR DESCRIPTION
Textarea for the rules is now wider and does not wrap long lines,
which might have look as 2 or more rules before, instead of 1.

Closes https://github.com/penge/block-site/issues/14