### PR TITLE
Block page before redirect

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "3.0.0",
   "icons": { "128": "icon.png" },
   "options_page": "options.html",
-  "permissions": ["storage", "tabs"],
+  "permissions": ["storage", "webNavigation"],
   "background": {
     "service_worker": "background.js"
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -24,8 +24,8 @@ chrome.runtime.onInstalled.addListener(function () {
   });
 });
 
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo) {
-  const { url } = changeInfo;
+chrome.webNavigation.onBeforeNavigate.addListener(function (details) {
+  const { tabId, url } = details;
   if (!url || !url.startsWith("http")) {
     return;
   }


### PR DESCRIPTION
This improvement can block page **even before redirecting** (example: `geforcenow.com` which redirects to `nvidia.com/en-eu/geforce-now`).

Changes in permissions: Replacing "tabs" with **"webNavigation"**.

Other benefit in using **"webNavigation"**: Blocking is noticeably faster as it happens before browser commited to the next URL.

Closes https://github.com/penge/block-site/issues/22