### PR TITLE
Fix - Ignore subframe navigation events

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -32,7 +32,7 @@ chrome.runtime.onInstalled.addListener(() => {
 
 chrome.webNavigation.onBeforeNavigate.addListener((details) => {
   const { tabId, url, timeStamp } = details;
-  if (!url || !url.startsWith("http")) {
+  if (!url || !url.startsWith("http") || details.frameId !== 0) {
     return;
   }
 


### PR DESCRIPTION
### Problem
Allowed URL is blocked if the page contains a subframe with blocked URL.

### Fix
Ignore subframe navigation events.

### More Info
https://developer.chrome.com/docs/extensions/reference/webNavigation/#event-onBeforeNavigate

### Reproduce Bug
1. Block `facebook.com`
2. Visit https://www.ebay.co.uk/itm/285002853148