### PR TITLE
Allow to block any page containing a word

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,46 +11,47 @@
 
 ## Usage
 
-Click on the icon. Enter sites to block. See [Examples](#examples).
+Click on the icon. Enter sites to block. See [Special characters](#special-characters) and [Examples](#examples).
 
 Choose how to resolve blocked: **Close Tab**, or **Show Blocked info page**.
 
 **Blocked info page** shows what _url_ was blocked, based on which _rule_ it was blocked, and optionally a blocked count over a chosen period of time:
 _All Time_, _This Month_, _This Week_, or _Today_.
 
+### Special characters
+
+```
+! ⇒ prepend to exclude from blocking
+* ⇒ match any zero or more characters
+? ⇒ match any one character
+```
+
 ### Examples
 
-Block `example.com` **only** (`example.com/apple/` and `orange.example.com` should work):
 ```
-example.com       # or example.com/
-```
+example.com/             # Blocks example.com/ ONLY
+example.com/*            # Blocks example.com/ and any page on it
 
-<br>
 
-Block any page on `example.com` (including `example.com`):
-```
-example.com/*
-```
+example.com/*            # Blocks any page on example.com/
+!example.com/orange/     # except example.com/orange/
 
-<br>
 
-Block any subdomain of `example.com` **only** (`example.com` should work):
-```
-*.example.com
-```
+*.example.com/           # Blocks any subdomain of example.com/
+!apple.example.com/      # except apple.example.com/
 
-<br>
 
-Block any page on `example.com` where first directory starts with any 4 characters (should block `example.com/pear/` or `example.com/plum/`, but not `example.com/orange/`):
-```
-example.com/????/*
-```
+*watch*                  # Blocks any page containing word "watch"
 
-<br>
 
-Block any page on `example.com` where first directory starts with any characters but ends with `rry` (should block `example.com/cherry/` or `example.com/strawberry/`, but not `example.com/kiwi/`):
-```
-example.com/*rry/
+example.com/????/*       # Blocks e.g.:
+                         # - example.com/pear/projects/1
+                         # - example.com/plum/projects/1
+
+
+example.com/*rry/*       # Blocks e.g.:
+                         # - example.com/cherry/projects/1
+                         # - example.com/strawberry/projects/1
 ```
 
 ## Privacy notice

--- a/public/blocked.css
+++ b/public/blocked.css
@@ -1,4 +1,27 @@
 #url, #rule {
   font-family: monospace;
-  opacity: .4;
+  padding: var(--border-radius);
+  border-radius: var(--border-radius);
+}
+
+#url {
+  background: #c6c6c6;
+  color: white;
+}
+
+#rule {
+  background: #ff0100;
+  color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+  #url {
+    background: #606060;
+    color: #121212;
+  }
+
+  #rule {
+    filter: saturate(50%);
+    color: #e8e8e8;
+  }
 }

--- a/public/common.css
+++ b/public/common.css
@@ -1,5 +1,6 @@
 :root {
   --background-color: white;
+  --border-radius: 3px;
   --text-color: black;
 }
 

--- a/public/options.css
+++ b/public/options.css
@@ -1,6 +1,5 @@
 :root {
   --border-color: black;
-  --border-radius: 3px;
   --input-background-color: white;
 }
 

--- a/src/helpers/__tests__/get-blocked-message.test.ts
+++ b/src/helpers/__tests__/get-blocked-message.test.ts
@@ -4,7 +4,7 @@ test("getBlockedMessage() returns blocked message", () => {
   expect(getBlockedMessage({
     url: "http://youtube.com/",
     rule: "youtube.com",
-  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> by rule <span id="rule">youtube.com</span>');
+  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> by <span id="rule">youtube.com</span>');
 
   expect(getBlockedMessage({
     url: "http://youtube.com/",
@@ -13,7 +13,7 @@ test("getBlockedMessage() returns blocked message", () => {
       count: 42,
       period: "ALL_TIME",
     },
-  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> (42x overall) by rule <span id="rule">youtube.com</span>');
+  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> by <span id="rule">youtube.com</span> (42x overall)');
 
   expect(getBlockedMessage({
     url: "http://youtube.com/",
@@ -22,7 +22,7 @@ test("getBlockedMessage() returns blocked message", () => {
       count: 5,
       period: "TODAY",
     },
-  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> (5x today) by rule <span id="rule">youtube.com</span>');
+  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> by <span id="rule">youtube.com</span> (5x today)');
 
   expect(getBlockedMessage({
     url: "http://youtube.com/",
@@ -31,7 +31,7 @@ test("getBlockedMessage() returns blocked message", () => {
       count: 12,
       period: "THIS_WEEK",
     },
-  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> (12x this week) by rule <span id="rule">youtube.com</span>');
+  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> by <span id="rule">youtube.com</span> (12x this week)');
 
   expect(getBlockedMessage({
     url: "http://youtube.com/",
@@ -40,5 +40,5 @@ test("getBlockedMessage() returns blocked message", () => {
       count: 38,
       period: "THIS_MONTH",
     },
-  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> (38x this month) by rule <span id="rule">youtube.com</span>');
+  })).toBe('<span id="url">http://youtube.com/</span> <b>was blocked</b> by <span id="rule">youtube.com</span> (38x this month)');
 });

--- a/src/helpers/__tests__/normalize-url.test.ts
+++ b/src/helpers/__tests__/normalize-url.test.ts
@@ -1,4 +1,4 @@
-import normalizeUrl, { appendTrailingSlashIfMissing } from "../normalize-url";
+import normalizeUrl from "../normalize-url";
 
 describe("normalizeUrl()", () => {
   it("removes https, http, www", () => {
@@ -31,12 +31,5 @@ describe("normalizeUrl()", () => {
     expect(normalizeUrl("https://example.com/apple/projects/")).toBe(
       "example.com/apple/projects/",
     );
-  });
-});
-
-describe("appendTrailingSlashIfMissing()", () => {
-  it("appends trailing slash if missing", () => {
-    expect(appendTrailingSlashIfMissing("example.com")).toBe("example.com/");
-    expect(appendTrailingSlashIfMissing("example.com/")).toBe("example.com/");
   });
 });

--- a/src/helpers/find-rule.ts
+++ b/src/helpers/find-rule.ts
@@ -1,4 +1,4 @@
-import normalizeUrl, { appendTrailingSlashIfMissing } from "./normalize-url";
+import normalizeUrl from "./normalize-url";
 import makeRules, { Rule } from "./make-rules";
 
 export default (url: string, blocked: string[]): Rule | undefined => {
@@ -8,20 +8,7 @@ export default (url: string, blocked: string[]): Rule | undefined => {
   const foundRule = rules.find((rule) =>
     normalizedUrl.match(new RegExp(
       "^"
-      /**
-       * To make it convenient for the user to block the root path (homepage),
-       * he can type either of:
-       * - example.com
-       * - example.com/
-       * and they both will work.
-       *
-       * To make this work, we append trailing slash if missing, and
-       * use that for the pattern matching.
-       *
-       * The original rule in "rules" remains unchanged,
-       * because it is the rule we would like to show to the user if blocked.
-       */
-      + appendTrailingSlashIfMissing(rule.path)
+      + rule.path
         .replace(/\?/g, ".")  // user can type "?" to match any one character
         .replace(/\*/g, ".*") // user can type "*" to match any zero or more characters
       + "$",

--- a/src/helpers/get-blocked-message.ts
+++ b/src/helpers/get-blocked-message.ts
@@ -8,6 +8,6 @@ const periodStrings: Record<CounterPeriod, string> = {
   TODAY: "today",
 };
 
-export default ({ url, rule, countParams: cp }: GetBlockedUrlParams): string => cp
-  ? `<span id="url">${url}</span> <b>was blocked</b> (${cp.count}x ${periodStrings[cp.period]}) by rule <span id="rule">${rule}</span>`
-  : `<span id="url">${url}</span> <b>was blocked</b> by rule <span id="rule">${rule}</span>`;
+export default ({ url, rule, countParams: cp }: GetBlockedUrlParams): string =>
+  `<span id="url">${url}</span> <b>was blocked</b> by <span id="rule">${rule}</span>`
+  + (cp ? ` (${cp.count}x ${periodStrings[cp.period]})` : "");

--- a/src/helpers/normalize-url.ts
+++ b/src/helpers/normalize-url.ts
@@ -5,5 +5,3 @@ export default (url: string): string => [url]
   .map(__removeProtocol)
   .map(__removeWww)
   .pop() as string;
-
-export const appendTrailingSlashIfMissing = (url: string) => url.split("/").length === 1 ? `${url}/` : url;


### PR DESCRIPTION
### Before

Trailing `/` was automatically added:
```
example.com    # same as example.com/
```

But it prevented to match by word:
```
*watch*        # should block https://www.youtube.com/watch?v=123456
               # but *watch* was changed to *watch*/
               # so there was no match
```

### Now

Trailing `/` is _NOT_ automatically added. Need to write:
```
example.com/
```

Which fixes matching by word:
```
*watch*        # will block https://www.youtube.com/watch?v=123456
```

<br><br>

Other changes:
- updating README (adding section **Special characters**, updating **Examples**)
- improving look of blocked info page (better contrast, moving count to the end of message)