### PR TITLE
Test version equality

### DIFF
--- a/public/manifest-chrome.json
+++ b/public/manifest-chrome.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Block Site",
   "description": "Blocks access to distracting websites to improve your productivity.",
-  "version": "8.2",
+  "version": "8.2.0",
   "icons": {
     "32": "icon_32.png",
     "128": "icon_128.png"

--- a/public/manifest-firefox.json
+++ b/public/manifest-firefox.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Block Site",
   "description": "Blocks access to distracting websites to improve your productivity.",
-  "version": "8.2",
+  "version": "8.2.0",
   "icons": {
     "32": "icon_32.png",
     "128": "icon_128.png"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "moduleResolution": "node",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "resolveJsonModule": true
   }
 }

--- a/version.test.ts
+++ b/version.test.ts
@@ -1,0 +1,17 @@
+import packageJson from "./package.json";
+import packageLockJson from "./package-lock.json";
+
+import manifestChromeJson from "./public/manifest-chrome.json";
+import manifestFirefoxJson from "./public/manifest-firefox.json";
+
+test("version equality", () => {
+  const { version } = packageJson;
+
+  [
+    packageLockJson.version,
+    manifestChromeJson.version,
+    manifestFirefoxJson.version,
+  ].forEach((aVersion) => {
+    expect(aVersion).toBe(version);
+  });
+});


### PR DESCRIPTION
Make sure all **"version"** fields are equally set. (To prevent accidentally releasing inconsistent versions.)

Test these files:

```
- package.json
- package-lock.json
- public/manifest-chrome.json
- public/manifest-firefox.json
```