### PR TITLE
Add time interval support for site blocking

### DIFF
--- a/src/helpers/__tests__/check-schedule.test.ts
+++ b/src/helpers/__tests__/check-schedule.test.ts
@@ -1,0 +1,254 @@
+import { isTimeInRange, isDayInRange, isWithinSchedule } from "../check-schedule";
+import { Schedule, TimeRange } from "../parse-time-interval";
+
+describe("isTimeInRange", () => {
+  test("time within normal range", () => {
+    const timeRange: TimeRange = { start: "9:00", end: "17:00" };
+
+    // 12:00 is within 9:00-17:00
+    const noon = new Date("2024-01-15T12:00:00");
+    expect(isTimeInRange(noon, timeRange)).toBe(true);
+
+    // 9:00 is within 9:00-17:00 (inclusive start)
+    const start = new Date("2024-01-15T09:00:00");
+    expect(isTimeInRange(start, timeRange)).toBe(true);
+
+    // 17:00 is within 9:00-17:00 (inclusive end)
+    const end = new Date("2024-01-15T17:00:00");
+    expect(isTimeInRange(end, timeRange)).toBe(true);
+  });
+
+  test("time outside normal range", () => {
+    const timeRange: TimeRange = { start: "9:00", end: "17:00" };
+
+    // 8:00 is before 9:00-17:00
+    const before = new Date("2024-01-15T08:00:00");
+    expect(isTimeInRange(before, timeRange)).toBe(false);
+
+    // 18:00 is after 9:00-17:00
+    const after = new Date("2024-01-15T18:00:00");
+    expect(isTimeInRange(after, timeRange)).toBe(false);
+
+    // Midnight is outside 9:00-17:00
+    const midnight = new Date("2024-01-15T00:00:00");
+    expect(isTimeInRange(midnight, timeRange)).toBe(false);
+  });
+
+  test("overnight range (22:00-6:00)", () => {
+    const overnightRange: TimeRange = { start: "22:00", end: "6:00" };
+
+    // 23:00 is within 22:00-6:00
+    const lateNight = new Date("2024-01-15T23:00:00");
+    expect(isTimeInRange(lateNight, overnightRange)).toBe(true);
+
+    // 0:00 is within 22:00-6:00
+    const midnight = new Date("2024-01-15T00:00:00");
+    expect(isTimeInRange(midnight, overnightRange)).toBe(true);
+
+    // 5:00 is within 22:00-6:00
+    const earlyMorning = new Date("2024-01-15T05:00:00");
+    expect(isTimeInRange(earlyMorning, overnightRange)).toBe(true);
+
+    // 22:00 is within 22:00-6:00 (inclusive start)
+    const start = new Date("2024-01-15T22:00:00");
+    expect(isTimeInRange(start, overnightRange)).toBe(true);
+
+    // 6:00 is within 22:00-6:00 (inclusive end)
+    const end = new Date("2024-01-15T06:00:00");
+    expect(isTimeInRange(end, overnightRange)).toBe(true);
+
+    // 12:00 is outside 22:00-6:00
+    const noon = new Date("2024-01-15T12:00:00");
+    expect(isTimeInRange(noon, overnightRange)).toBe(false);
+
+    // 21:00 is outside 22:00-6:00
+    const evening = new Date("2024-01-15T21:00:00");
+    expect(isTimeInRange(evening, overnightRange)).toBe(false);
+
+    // 7:00 is outside 22:00-6:00
+    const morning = new Date("2024-01-15T07:00:00");
+    expect(isTimeInRange(morning, overnightRange)).toBe(false);
+  });
+
+  test("with minutes", () => {
+    const timeRange: TimeRange = { start: "8:30", end: "18:45" };
+
+    // 8:31 is within 8:30-18:45
+    const justAfterStart = new Date("2024-01-15T08:31:00");
+    expect(isTimeInRange(justAfterStart, timeRange)).toBe(true);
+
+    // 8:29 is outside 8:30-18:45
+    const justBeforeStart = new Date("2024-01-15T08:29:00");
+    expect(isTimeInRange(justBeforeStart, timeRange)).toBe(false);
+
+    // 18:44 is within 8:30-18:45
+    const justBeforeEnd = new Date("2024-01-15T18:44:00");
+    expect(isTimeInRange(justBeforeEnd, timeRange)).toBe(true);
+
+    // 18:46 is outside 8:30-18:45
+    const justAfterEnd = new Date("2024-01-15T18:46:00");
+    expect(isTimeInRange(justAfterEnd, timeRange)).toBe(false);
+  });
+});
+
+describe("isDayInRange", () => {
+  test("null days (all days)", () => {
+    const monday = new Date("2024-01-15T12:00:00"); // Monday
+    const sunday = new Date("2024-01-14T12:00:00"); // Sunday
+
+    expect(isDayInRange(monday, null)).toBe(true);
+    expect(isDayInRange(sunday, null)).toBe(true);
+  });
+
+  test("weekdays (Mon-Fri)", () => {
+    const weekdays = [1, 2, 3, 4, 5]; // Mon-Fri
+
+    const monday = new Date("2024-01-15T12:00:00");
+    expect(isDayInRange(monday, weekdays)).toBe(true);
+
+    const friday = new Date("2024-01-19T12:00:00");
+    expect(isDayInRange(friday, weekdays)).toBe(true);
+
+    const saturday = new Date("2024-01-20T12:00:00");
+    expect(isDayInRange(saturday, weekdays)).toBe(false);
+
+    const sunday = new Date("2024-01-21T12:00:00");
+    expect(isDayInRange(sunday, weekdays)).toBe(false);
+  });
+
+  test("weekend (Sat-Sun)", () => {
+    const weekend = [6, 0]; // Sat-Sun
+
+    const saturday = new Date("2024-01-20T12:00:00");
+    expect(isDayInRange(saturday, weekend)).toBe(true);
+
+    const sunday = new Date("2024-01-21T12:00:00");
+    expect(isDayInRange(sunday, weekend)).toBe(true);
+
+    const monday = new Date("2024-01-15T12:00:00");
+    expect(isDayInRange(monday, weekend)).toBe(false);
+
+    const friday = new Date("2024-01-19T12:00:00");
+    expect(isDayInRange(friday, weekend)).toBe(false);
+  });
+
+  test("single day", () => {
+    const mondayOnly = [1];
+
+    const monday = new Date("2024-01-15T12:00:00");
+    expect(isDayInRange(monday, mondayOnly)).toBe(true);
+
+    const tuesday = new Date("2024-01-16T12:00:00");
+    expect(isDayInRange(tuesday, mondayOnly)).toBe(false);
+  });
+});
+
+describe("isWithinSchedule", () => {
+  test("null schedule (24/7)", () => {
+    const anytime = new Date("2024-01-15T12:00:00");
+    expect(isWithinSchedule(null, anytime)).toBe(true);
+
+    const midnight = new Date("2024-01-15T00:00:00");
+    expect(isWithinSchedule(null, midnight)).toBe(true);
+  });
+
+  test("time only schedule", () => {
+    const schedule: Schedule = {
+      days: null,
+      timeRange: { start: "9:00", end: "17:00" },
+    };
+
+    // Within time range
+    const noon = new Date("2024-01-15T12:00:00");
+    expect(isWithinSchedule(schedule, noon)).toBe(true);
+
+    // Outside time range
+    const evening = new Date("2024-01-15T20:00:00");
+    expect(isWithinSchedule(schedule, evening)).toBe(false);
+  });
+
+  test("days only schedule", () => {
+    const schedule: Schedule = {
+      days: [1, 2, 3, 4, 5], // Mon-Fri
+      timeRange: null,
+    };
+
+    // Weekday
+    const monday = new Date("2024-01-15T12:00:00");
+    expect(isWithinSchedule(schedule, monday)).toBe(true);
+
+    // Weekend
+    const saturday = new Date("2024-01-20T12:00:00");
+    expect(isWithinSchedule(schedule, saturday)).toBe(false);
+  });
+
+  test("days and time schedule", () => {
+    const schedule: Schedule = {
+      days: [1, 2, 3, 4, 5], // Mon-Fri
+      timeRange: { start: "9:00", end: "17:00" },
+    };
+
+    // Monday noon - within schedule
+    const mondayNoon = new Date("2024-01-15T12:00:00");
+    expect(isWithinSchedule(schedule, mondayNoon)).toBe(true);
+
+    // Monday evening - correct day but wrong time
+    const mondayEvening = new Date("2024-01-15T20:00:00");
+    expect(isWithinSchedule(schedule, mondayEvening)).toBe(false);
+
+    // Saturday noon - correct time but wrong day
+    const saturdayNoon = new Date("2024-01-20T12:00:00");
+    expect(isWithinSchedule(schedule, saturdayNoon)).toBe(false);
+
+    // Saturday evening - wrong day and wrong time
+    const saturdayEvening = new Date("2024-01-20T20:00:00");
+    expect(isWithinSchedule(schedule, saturdayEvening)).toBe(false);
+  });
+
+  test("weekend all day", () => {
+    const schedule: Schedule = {
+      days: [6, 0], // Sat-Sun
+      timeRange: null,
+    };
+
+    // Saturday at any time - within schedule
+    const saturdayMorning = new Date("2024-01-20T06:00:00");
+    expect(isWithinSchedule(schedule, saturdayMorning)).toBe(true);
+
+    const saturdayNight = new Date("2024-01-20T23:00:00");
+    expect(isWithinSchedule(schedule, saturdayNight)).toBe(true);
+
+    // Monday - outside schedule
+    const monday = new Date("2024-01-15T12:00:00");
+    expect(isWithinSchedule(schedule, monday)).toBe(false);
+  });
+
+  test("overnight schedule", () => {
+    const schedule: Schedule = {
+      days: null,
+      timeRange: { start: "22:00", end: "6:00" },
+    };
+
+    // 23:00 - within schedule
+    const lateNight = new Date("2024-01-15T23:00:00");
+    expect(isWithinSchedule(schedule, lateNight)).toBe(true);
+
+    // 3:00 - within schedule
+    const earlyMorning = new Date("2024-01-15T03:00:00");
+    expect(isWithinSchedule(schedule, earlyMorning)).toBe(true);
+
+    // 12:00 - outside schedule
+    const noon = new Date("2024-01-15T12:00:00");
+    expect(isWithinSchedule(schedule, noon)).toBe(false);
+  });
+
+  test("uses current time when not provided", () => {
+    const schedule: Schedule = {
+      days: null,
+      timeRange: null,
+    };
+
+    // Should not throw and should return true for null timeRange
+    expect(isWithinSchedule(schedule)).toBe(true);
+  });
+});

--- a/src/helpers/__tests__/find-rule.test.ts
+++ b/src/helpers/__tests__/find-rule.test.ts
@@ -34,6 +34,7 @@ describe("findRule()", () => {
       ].forEach((url) => expect(findRule(url, ["example.com/"])).toEqual<Rule>({
         type: "block",
         path: "example.com/",
+        schedule: null,
       }));
     });
   });
@@ -43,6 +44,7 @@ describe("findRule()", () => {
       expect(findRule("https://example.com/", ["example.com/"])).toEqual<Rule>({
         type: "block",
         path: "example.com/",
+        schedule: null,
       });
 
       expect(findRule("https://dashboard.example.com/", ["example.com/"])).toBeUndefined();
@@ -52,6 +54,7 @@ describe("findRule()", () => {
       expect(findRule("https://dashboard.example.com/", ["dashboard.example.com/"])).toEqual<Rule>({
         type: "block",
         path: "dashboard.example.com/",
+        schedule: null,
       });
 
       expect(findRule("https://example.com/", ["dashboard.example.com/"])).toBeUndefined();
@@ -65,6 +68,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, ["*.example.com/"])).toEqual<Rule>({
           type: "block",
           path: "*.example.com/",
+          schedule: null,
         }));
 
         expect(findRule("https://example.com/", ["*.example.com/"])).toBeUndefined();
@@ -76,6 +80,7 @@ describe("findRule()", () => {
           expect(findRule("https://www.facebook.com/", [blocked])).toEqual<Rule>({
             type: "block",
             path: blocked,
+            schedule: null,
           });
         });
 
@@ -95,6 +100,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, blocked)).toEqual<Rule>({
           type: "block",
           path: blocked[0],
+          schedule: null,
         }));
 
         [
@@ -112,6 +118,7 @@ describe("findRule()", () => {
         expect(findRule("https://www.facebook.com/", [blocked])).toEqual<Rule>({
           type: "block",
           path: blocked,
+          schedule: null,
         });
       });
     });
@@ -124,6 +131,7 @@ describe("findRule()", () => {
         expect(findRule(url, ["example.com"])).toEqual<Rule>({
           type: "block",
           path: "example.com",
+          schedule: null,
         });
       });
 
@@ -134,6 +142,7 @@ describe("findRule()", () => {
         expect(findRule(url, ["dashboard.example.com"])).toEqual<Rule>({
           type: "block",
           path: "dashboard.example.com",
+          schedule: null,
         });
       });
 
@@ -156,6 +165,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, ["example.com/*"])).toEqual<Rule>({
           type: "block",
           path: "example.com/*",
+          schedule: null,
         }));
       });
 
@@ -166,6 +176,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, ["example.com/app*"])).toEqual<Rule>({
           type: "block",
           path: "example.com/app*",
+          schedule: null,
         }));
 
         [
@@ -181,6 +192,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, ["example.com/*rry/"])).toEqual<Rule>({
           type: "block",
           path: "example.com/*rry/",
+          schedule: null,
         }));
       });
 
@@ -188,6 +200,7 @@ describe("findRule()", () => {
         expect(findRule("https://www.youtube.com/watch?v=123456", ["*watch*"])).toEqual<Rule>({
           type: "block",
           path: "*watch*",
+          schedule: null,
         });
 
         [
@@ -198,6 +211,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, ["*proxy*"])).toEqual<Rule>({
           type: "block",
           path: "*proxy*",
+          schedule: null,
         }));
       });
     });
@@ -207,6 +221,7 @@ describe("findRule()", () => {
         expect(findRule("https://example.com/banana/", ["example.com/??nana/"])).toEqual<Rule>({
           type: "block",
           path: "example.com/??nana/",
+          schedule: null,
         });
       });
     });
@@ -224,6 +239,7 @@ describe("findRule()", () => {
         ].forEach((url) => expect(findRule(url, blocked)).toEqual<Rule>({
           type: "block",
           path: blocked[0],
+          schedule: null,
         }));
 
         [
@@ -247,11 +263,13 @@ describe("findRule()", () => {
       expect(findRule("https://banana.example.com/", blockedExcludedDomain)).toEqual<Rule>({
         type: "block",
         path: "*.example.com/",
+        schedule: null,
       });
 
       expect(findRule("https://apple.example.com/", blockedExcludedDomain)).toEqual<Rule>({
         type: "allow",
         path: "apple.example.com/",
+        schedule: null,
       });
     });
 
@@ -264,11 +282,13 @@ describe("findRule()", () => {
       expect(findRule("https://example.com/apple/", blockedExcludedPath)).toEqual<Rule>({
         type: "block",
         path: "example.com/*",
+        schedule: null,
       });
 
       expect(findRule("https://example.com/strawberry/", blockedExcludedPath)).toEqual<Rule>({
         type: "allow",
         path: "example.com/strawberry/",
+        schedule: null,
       });
     });
   });

--- a/src/helpers/__tests__/make-rules.test.ts
+++ b/src/helpers/__tests__/make-rules.test.ts
@@ -1,6 +1,6 @@
 import makeRules, { Rule } from "../make-rules";
 
-test("makeRules()", () => {
+test("makeRules() - backward compatibility", () => {
   expect(
     makeRules([
       "www.facebook.com",
@@ -13,13 +13,77 @@ test("makeRules()", () => {
       "!reddit.com/r/MachineLearning",
     ]),
   ).toEqual<Rule[]>([
-    { type: "allow", path: "music.youtube.com" },
-    { type: "allow", path: "reddit.com/r/MachineLearning" },
+    { type: "allow", path: "music.youtube.com", schedule: null },
+    { type: "allow", path: "reddit.com/r/MachineLearning", schedule: null },
 
-    { type: "block", path: "www.facebook.com" },
-    { type: "block", path: "www.instagram.com/" },
+    { type: "block", path: "www.facebook.com", schedule: null },
+    { type: "block", path: "www.instagram.com/", schedule: null },
 
-    { type: "block", path: "*.youtube.com" },
-    { type: "block", path: "reddit.com" },
+    { type: "block", path: "*.youtube.com", schedule: null },
+    { type: "block", path: "reddit.com", schedule: null },
+  ]);
+});
+
+test("makeRules() - with time intervals", () => {
+  expect(
+    makeRules([
+      "example.com 9:00-17:00",
+      "facebook.com Mon-Fri 9:00-17:00",
+      "youtube.com Sat-Sun",
+      "reddit.com",
+    ]),
+  ).toEqual<Rule[]>([
+    {
+      type: "block",
+      path: "example.com",
+      schedule: {
+        days: null,
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    },
+    {
+      type: "block",
+      path: "facebook.com",
+      schedule: {
+        days: [1, 2, 3, 4, 5],
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    },
+    {
+      type: "block",
+      path: "youtube.com",
+      schedule: {
+        days: [6, 0],
+        timeRange: null,
+      },
+    },
+    {
+      type: "block",
+      path: "reddit.com",
+      schedule: null,
+    },
+  ]);
+});
+
+test("makeRules() - with comments", () => {
+  expect(
+    makeRules([
+      "example.com 9:00-17:00 # work hours",
+      "facebook.com # blocked all day",
+    ]),
+  ).toEqual<Rule[]>([
+    {
+      type: "block",
+      path: "example.com",
+      schedule: {
+        days: null,
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    },
+    {
+      type: "block",
+      path: "facebook.com",
+      schedule: null,
+    },
   ]);
 });

--- a/src/helpers/__tests__/parse-time-interval.test.ts
+++ b/src/helpers/__tests__/parse-time-interval.test.ts
@@ -1,0 +1,225 @@
+import { isValidTime, parseTimeRange, parseDayRange, parseEntry } from "../parse-time-interval";
+
+describe("isValidTime", () => {
+  test("valid times", () => {
+    expect(isValidTime("9:00")).toBe(true);
+    expect(isValidTime("17:00")).toBe(true);
+    expect(isValidTime("0:00")).toBe(true);
+    expect(isValidTime("23:59")).toBe(true);
+    expect(isValidTime("08:30")).toBe(true);
+  });
+
+  test("invalid times", () => {
+    expect(isValidTime("25:00")).toBe(false);
+    expect(isValidTime("9:70")).toBe(false);
+    expect(isValidTime("24:00")).toBe(false);
+    expect(isValidTime("abc")).toBe(false);
+    expect(isValidTime("9:0")).toBe(false); // minutes must be 2 digits
+    expect(isValidTime("9")).toBe(false);
+  });
+});
+
+describe("parseTimeRange", () => {
+  test("valid time ranges", () => {
+    expect(parseTimeRange("9:00-17:00")).toEqual({
+      start: "9:00",
+      end: "17:00",
+    });
+
+    expect(parseTimeRange("08:30-18:45")).toEqual({
+      start: "08:30",
+      end: "18:45",
+    });
+
+    expect(parseTimeRange("0:00-23:59")).toEqual({
+      start: "0:00",
+      end: "23:59",
+    });
+
+    // Overnight range
+    expect(parseTimeRange("22:00-6:00")).toEqual({
+      start: "22:00",
+      end: "6:00",
+    });
+  });
+
+  test("invalid time ranges", () => {
+    expect(parseTimeRange("25:00-26:00")).toBeNull();
+    expect(parseTimeRange("9:70-10:00")).toBeNull();
+    expect(parseTimeRange("abc-def")).toBeNull();
+    expect(parseTimeRange("9:00")).toBeNull(); // missing end time
+    expect(parseTimeRange("9:00-")).toBeNull();
+    expect(parseTimeRange("-17:00")).toBeNull();
+  });
+});
+
+describe("parseDayRange", () => {
+  test("valid day ranges", () => {
+    expect(parseDayRange("Mon-Fri")).toEqual([1, 2, 3, 4, 5]);
+    expect(parseDayRange("Sat-Sun")).toEqual([6, 0]);
+    expect(parseDayRange("Mon-Wed")).toEqual([1, 2, 3]);
+    expect(parseDayRange("Thu-Sat")).toEqual([4, 5, 6]);
+  });
+
+  test("single days", () => {
+    expect(parseDayRange("Mon")).toEqual([1]);
+    expect(parseDayRange("Tue")).toEqual([2]);
+    expect(parseDayRange("Wed")).toEqual([3]);
+    expect(parseDayRange("Thu")).toEqual([4]);
+    expect(parseDayRange("Fri")).toEqual([5]);
+    expect(parseDayRange("Sat")).toEqual([6]);
+    expect(parseDayRange("Sun")).toEqual([0]);
+  });
+
+  test("Sun-Sat covers all days", () => {
+    // Sun-Sat is valid and represents all 7 days
+    expect(parseDayRange("Sun-Sat")).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  test("invalid day ranges", () => {
+    // Wrapping ranges not allowed
+    expect(parseDayRange("Fri-Mon")).toBeNull();
+    expect(parseDayRange("Thu-Mon")).toBeNull();
+
+    expect(parseDayRange("abc-def")).toBeNull();
+    expect(parseDayRange("Monday")).toBeNull(); // Must use abbreviation
+    expect(parseDayRange("Mon-")).toBeNull();
+    expect(parseDayRange("-Fri")).toBeNull();
+  });
+});
+
+describe("parseEntry", () => {
+  test("entries without time intervals", () => {
+    expect(parseEntry("example.com")).toEqual({
+      path: "example.com",
+      schedule: null,
+    });
+
+    expect(parseEntry("*.youtube.com")).toEqual({
+      path: "*.youtube.com",
+      schedule: null,
+    });
+  });
+
+  test("entries with time only", () => {
+    expect(parseEntry("example.com 9:00-17:00")).toEqual({
+      path: "example.com",
+      schedule: {
+        days: null,
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    });
+
+    expect(parseEntry("facebook.com 08:30-18:45")).toEqual({
+      path: "facebook.com",
+      schedule: {
+        days: null,
+        timeRange: { start: "08:30", end: "18:45" },
+      },
+    });
+  });
+
+  test("entries with days only", () => {
+    expect(parseEntry("youtube.com Sat-Sun")).toEqual({
+      path: "youtube.com",
+      schedule: {
+        days: [6, 0],
+        timeRange: null,
+      },
+    });
+
+    expect(parseEntry("example.com Mon")).toEqual({
+      path: "example.com",
+      schedule: {
+        days: [1],
+        timeRange: null,
+      },
+    });
+  });
+
+  test("entries with both days and time", () => {
+    expect(parseEntry("facebook.com Mon-Fri 9:00-17:00")).toEqual({
+      path: "facebook.com",
+      schedule: {
+        days: [1, 2, 3, 4, 5],
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    });
+
+    expect(parseEntry("example.com Sat-Sun 10:00-22:00")).toEqual({
+      path: "example.com",
+      schedule: {
+        days: [6, 0],
+        timeRange: { start: "10:00", end: "22:00" },
+      },
+    });
+
+    // Order shouldn't matter
+    expect(parseEntry("example.com 9:00-17:00 Mon-Fri")).toEqual({
+      path: "example.com",
+      schedule: {
+        days: [1, 2, 3, 4, 5],
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    });
+  });
+
+  test("entries with comments", () => {
+    expect(parseEntry("example.com 9:00-17:00 # work hours")).toEqual({
+      path: "example.com",
+      schedule: {
+        days: null,
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    });
+
+    expect(parseEntry("facebook.com # blocked all day")).toEqual({
+      path: "facebook.com",
+      schedule: null,
+    });
+  });
+
+  test("entries with wildcards and time", () => {
+    expect(parseEntry("*.social.com Mon-Fri 9:00-17:00")).toEqual({
+      path: "*.social.com",
+      schedule: {
+        days: [1, 2, 3, 4, 5],
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    });
+  });
+
+  test("entries with invalid time fall back to 24/7", () => {
+    expect(parseEntry("example.com 25:00-26:00")).toEqual({
+      path: "example.com",
+      schedule: null,
+    });
+
+    expect(parseEntry("example.com invalid")).toEqual({
+      path: "example.com",
+      schedule: null,
+    });
+  });
+
+  test("empty entries", () => {
+    expect(parseEntry("")).toEqual({
+      path: "",
+      schedule: null,
+    });
+
+    expect(parseEntry("   ")).toEqual({
+      path: "",
+      schedule: null,
+    });
+  });
+
+  test("extra whitespace", () => {
+    expect(parseEntry("  example.com  9:00-17:00  ")).toEqual({
+      path: "example.com",
+      schedule: {
+        days: null,
+        timeRange: { start: "9:00", end: "17:00" },
+      },
+    });
+  });
+});

--- a/src/helpers/block-site.ts
+++ b/src/helpers/block-site.ts
@@ -2,6 +2,7 @@ import storage from "../storage";
 import findRule from "./find-rule";
 import * as counterHelper from "./counter";
 import getBlockedUrl from "./get-blocked-url";
+import { isWithinSchedule } from "./check-schedule";
 
 interface BlockSiteOptions {
   blocked: string[]
@@ -21,6 +22,12 @@ export default (options: BlockSiteOptions) => {
       counterHelper.flushObsoleteEntries({ blocked, counter });
       storage.set({ counter });
     });
+    return;
+  }
+
+  // Check if current time is within the blocking schedule
+  if (!isWithinSchedule(foundRule.schedule)) {
+    // Outside schedule - don't block
     return;
   }
 

--- a/src/helpers/check-schedule.ts
+++ b/src/helpers/check-schedule.ts
@@ -1,0 +1,66 @@
+import { Schedule, TimeRange } from "./parse-time-interval";
+
+/**
+ * Checks if the current time is within a time range
+ * Handles overnight ranges (e.g., 22:00-6:00)
+ */
+export const isTimeInRange = (now: Date, timeRange: TimeRange): boolean => {
+  const currentHours = now.getHours();
+  const currentMinutes = now.getMinutes();
+  const currentTimeInMinutes = currentHours * 60 + currentMinutes;
+
+  // Parse start time
+  const [startHours, startMinutes] = timeRange.start.split(":").map(Number);
+  const startTimeInMinutes = startHours * 60 + startMinutes;
+
+  // Parse end time
+  const [endHours, endMinutes] = timeRange.end.split(":").map(Number);
+  const endTimeInMinutes = endHours * 60 + endMinutes;
+
+  // Handle overnight range (e.g., 22:00-6:00)
+  if (startTimeInMinutes > endTimeInMinutes) {
+    // Current time is in range if it's >= start OR <= end
+    return currentTimeInMinutes >= startTimeInMinutes || currentTimeInMinutes <= endTimeInMinutes;
+  }
+
+  // Normal range (e.g., 9:00-17:00)
+  return currentTimeInMinutes >= startTimeInMinutes && currentTimeInMinutes <= endTimeInMinutes;
+};
+
+/**
+ * Checks if the current day is within the specified days
+ * null days means all days are included
+ */
+export const isDayInRange = (now: Date, days: number[] | null): boolean => {
+  if (days === null) {
+    return true; // All days
+  }
+
+  const currentDay = now.getDay();
+  return days.includes(currentDay);
+};
+
+/**
+ * Checks if the current time matches the schedule
+ * null schedule means 24/7 (always matches)
+ * null timeRange means all day
+ * null days means all days
+ */
+export const isWithinSchedule = (schedule: Schedule | null, now: Date = new Date()): boolean => {
+  // No schedule means 24/7 blocking
+  if (schedule === null) {
+    return true;
+  }
+
+  // Check day
+  if (!isDayInRange(now, schedule.days)) {
+    return false;
+  }
+
+  // Check time
+  if (schedule.timeRange === null) {
+    return true; // All day
+  }
+
+  return isTimeInRange(now, schedule.timeRange);
+};

--- a/src/helpers/make-rules.ts
+++ b/src/helpers/make-rules.ts
@@ -1,23 +1,39 @@
 import removeProtocol from "./remove-protocol";
+import { parseEntry, Schedule } from "./parse-time-interval";
 
 type RuleType = "allow" | "block"
 
 export interface Rule {
   type: RuleType
   path: string
+  schedule: Schedule | null
 }
 
 export default (blocked: string[]): Rule[] => {
+  const processEntry = (item: string, isAllow: boolean): Rule => {
+    // Strip comments
+    const cleanItem = item.split("#")[0].trim();
+
+    // Parse path and schedule
+    const { path, schedule } = parseEntry(cleanItem);
+
+    // Remove protocol from path
+    const cleanPath = removeProtocol(path);
+
+    return {
+      type: isAllow ? "allow" : "block",
+      path: cleanPath,
+      schedule,
+    };
+  };
+
   const allowList = blocked
     .filter((item) => item.startsWith("!"))
-    .map((item) => removeProtocol(item.substring(1)));
+    .map((item) => processEntry(item.substring(1), true));
 
   const blockList = blocked
     .filter((item) => !item.startsWith("!"))
-    .map(removeProtocol);
+    .map((item) => processEntry(item, false));
 
-  return [
-    ...allowList.map((path) => ({ type: "allow", path } as Rule)),
-    ...blockList.map((path) => ({ type: "block", path } as Rule)),
-  ];
+  return [...allowList, ...blockList];
 };

--- a/src/helpers/parse-time-interval.ts
+++ b/src/helpers/parse-time-interval.ts
@@ -1,0 +1,160 @@
+export interface TimeRange {
+  start: string;  // "9:00"
+  end: string;    // "17:00"
+}
+
+export interface Schedule {
+  days: number[] | null;      // [1,2,3,4,5] for Mon-Fri, null = all days
+  timeRange: TimeRange | null; // null = all day
+}
+
+export interface ParsedEntry {
+  path: string;              // "example.com"
+  schedule: Schedule | null; // null = 24/7 blocking
+}
+
+const DAY_NAMES: Record<string, number> = {
+  "Sun": 0,
+  "Mon": 1,
+  "Tue": 2,
+  "Wed": 3,
+  "Thu": 4,
+  "Fri": 5,
+  "Sat": 6,
+};
+
+/**
+ * Validates if a time string is in valid HH:MM format
+ */
+export const isValidTime = (time: string): boolean => {
+  const match = time.match(/^(\d{1,2}):(\d{2})$/);
+  if (!match) return false;
+
+  const hours = parseInt(match[1], 10);
+  const minutes = parseInt(match[2], 10);
+
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
+};
+
+/**
+ * Parses a time range string like "9:00-17:00"
+ * Returns null if invalid format
+ */
+export const parseTimeRange = (timeStr: string): TimeRange | null => {
+  const match = timeStr.match(/^(\d{1,2}:\d{2})-(\d{1,2}:\d{2})$/);
+  if (!match) return null;
+
+  const start = match[1];
+  const end = match[2];
+
+  if (!isValidTime(start) || !isValidTime(end)) {
+    return null;
+  }
+
+  return { start, end };
+};
+
+/**
+ * Parses a day range string like "Mon-Fri" or single day like "Mon"
+ * Returns array of day numbers (0=Sunday, 1=Monday, etc.)
+ * Returns null if invalid format
+ */
+export const parseDayRange = (dayStr: string): number[] | null => {
+  // Check for single day
+  if (DAY_NAMES[dayStr] !== undefined) {
+    return [DAY_NAMES[dayStr]];
+  }
+
+  // Check for day range
+  const match = dayStr.match(/^(Mon|Tue|Wed|Thu|Fri|Sat|Sun)-(Mon|Tue|Wed|Thu|Fri|Sat|Sun)$/);
+  if (!match) return null;
+
+  const startDay = DAY_NAMES[match[1]];
+  const endDay = DAY_NAMES[match[2]];
+
+  // Special case: Sat-Sun (6-0) is valid
+  if (startDay === 6 && endDay === 0) {
+    return [6, 0];
+  }
+
+  // Don't allow other wrapping ranges like "Fri-Mon" or "Sun-Sat"
+  if (startDay > endDay) {
+    return null;
+  }
+
+  // Generate array of days from start to end (inclusive)
+  const days: number[] = [];
+  for (let i = startDay; i <= endDay; i++) {
+    days.push(i);
+  }
+
+  return days;
+};
+
+/**
+ * Parses a site entry with optional time interval and day range
+ * Examples:
+ *   - "example.com" → { path: "example.com", schedule: null }
+ *   - "example.com 9:00-17:00" → { path: "example.com", schedule: { days: null, timeRange: {...} } }
+ *   - "facebook.com Mon-Fri 9:00-17:00" → { path: "facebook.com", schedule: { days: [1,2,3,4,5], timeRange: {...} } }
+ *   - "youtube.com Sat-Sun" → { path: "youtube.com", schedule: { days: [0,6], timeRange: null } }
+ */
+export const parseEntry = (entry: string): ParsedEntry => {
+  // Strip comments (everything after #)
+  const cleanEntry = entry.split("#")[0].trim();
+
+  // Split by whitespace
+  const parts = cleanEntry.split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return { path: "", schedule: null };
+  }
+
+  // First part is always the path
+  const path = parts[0];
+
+  // If only one part, no schedule
+  if (parts.length === 1) {
+    return { path, schedule: null };
+  }
+
+  // Try to parse remaining parts for days and time
+  let days: number[] | null = null;
+  let timeRange: TimeRange | null = null;
+
+  for (let i = 1; i < parts.length; i++) {
+    const part = parts[i];
+
+    // Try to parse as time range
+    if (!timeRange) {
+      const parsedTime = parseTimeRange(part);
+      if (parsedTime) {
+        timeRange = parsedTime;
+        continue;
+      }
+    }
+
+    // Try to parse as day range
+    if (!days) {
+      const parsedDays = parseDayRange(part);
+      if (parsedDays) {
+        days = parsedDays;
+        continue;
+      }
+    }
+  }
+
+  // If we found either days or time, create a schedule
+  if (days || timeRange) {
+    return {
+      path,
+      schedule: {
+        days,
+        timeRange,
+      },
+    };
+  }
+
+  // No valid schedule found, fall back to 24/7
+  return { path, schedule: null };
+};

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -55,4 +55,9 @@ export const BLOCKED_EXAMPLE: string[] = [
 
   "example.com/???/     # ? = any one character",
   "example.com/app/*",
+  "",
+
+  "example.com 9:00-17:00              # block 9am-5pm daily",
+  "facebook.com Mon-Fri 9:00-17:00     # block weekdays only",
+  "youtube.com Sat-Sun                 # block weekends all day",
 ];


### PR DESCRIPTION
## Summary

This PR adds the ability to specify time intervals and day ranges for when sites should be blocked. Sites without time intervals continue to be blocked 24/7, maintaining full backward compatibility.

## New Features

### Time Interval Syntax

Users can now add time ranges and day ranges to their blocked sites:

```
example.com 9:00-17:00                  # Block daily from 9am to 5pm
facebook.com Mon-Fri 9:00-17:00         # Block weekdays during work hours
youtube.com Sat-Sun                     # Block all weekend
reddit.com                              # Block 24/7 (backward compatible)
*.social.com Mon-Fri 8:00-18:00         # Wildcards work with time intervals
!allowed.example.com                    # Exclusions still work
```

### Supported Formats

- **Time ranges**: 24-hour format (e.g., `9:00-17:00`, `08:30-18:45`)
- **Overnight ranges**: `22:00-6:00` (blocks from 10pm to 6am)
- **Day ranges**: `Mon-Fri`, `Sat-Sun`, `Thu-Sat`
- **Single days**: `Mon`, `Tue`, `Wed`, etc.
- **All combinations**: Time only, days only, or both

## Implementation

### New Files
- `src/helpers/parse-time-interval.ts` - Parsing logic for time intervals and day ranges
- `src/helpers/check-schedule.ts` - Time validation logic
- `src/helpers/__tests__/parse-time-interval.test.ts` - 17 tests for parsing
- `src/helpers/__tests__/check-schedule.test.ts` - 12 tests for schedule checking

### Modified Files
- `src/helpers/make-rules.ts` - Extended `Rule` interface with optional `schedule` field
- `src/helpers/block-site.ts` - Added schedule checking before blocking
- `src/storage/schema.ts` - Updated examples to show time interval syntax
- Test files updated to include new `schedule` field

## Testing

- ✅ All 67 tests passing
- ✅ Full backward compatibility (sites without time intervals block 24/7)
- ✅ Build successful for both Chrome and Firefox
- ✅ Comprehensive test coverage for edge cases:
  - Overnight ranges
  - Invalid formats (graceful fallback to 24/7)
  - Day range validation
  - Time validation

## Edge Cases Handled

1. **Overnight ranges**: `22:00-6:00` correctly blocks from 10pm to 6am
2. **Invalid syntax**: Falls back to 24/7 blocking (safe default)
3. **Special day ranges**: `Sat-Sun` (weekend) properly handled
4. **Timezone**: Uses browser local time
5. **Comments**: Time intervals work with comment syntax (`example.com 9:00-17:00 # work hours`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)